### PR TITLE
Change repo from JCenter to maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ nexusStaging {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -15,7 +15,7 @@ version = "0.0.1"
 description = "an example of the client library for Vald (https://github.com/vdaas/vald)."
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
Since JCenter is shutdown, the repo used will be changed to maven.
Ref: https://blog.gradle.org/jcenter-shutdown