### PR TITLE
compose javadoc into artifactory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,3 +154,9 @@ signing {
         sign publishing.publications.mavenJava
     }
 }
+
+javadoc {
+    if(JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+}


### PR DESCRIPTION
From the investigation at Nexus UI, it may be no javaDoc file.
I try to compose javadoc file into publication.

I referred:
https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:complete_example

Signed-off-by: vankichi <kyukawa315@gmail.com>