### PR TITLE
Fix fossa error

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '17'
       - name: 'Install fossa-cli'
         run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
       - name: 'Run for main branch'
         if: github.ref == 'refs/heads/main'
         run: |


### PR DESCRIPTION
This PR updates the fossa version to fix the following fossa error caused by default offline mode on old version of fossa.
```
TROUBLESHOOTING: Fossa could not run
`/__w/vald-client-java/vald-client-java/gradlew ::dependencies --quiet -p .
--offline` within the current directory. Try running this command and ensure
that gradle is installed in your environment.

...

> Could not resolve all files for configuration ':classpath'.
   > Could not resolve
io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0.
```

In fossa cli v3, the `online` option is removed and the dependency can be resolved automatically.
ref: https://github.com/fossas/fossa-cli/blob/master/docs/differences-from-v1.md#gradle