### PR TITLE
Fix proto build error due to new dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,8 @@ vald/update: \
 ## install proto deps
 proto/deps: \
 	$(PROTO_DEPS_PATH)/github.com/googleapis/googleapis \
-	$(PROTO_DEPS_PATH)/github.com/envoyproxy/protoc-gen-validate
+	$(PROTO_DEPS_PATH)/github.com/envoyproxy/protoc-gen-validate \
+	$(PROTO_DEPS_PATH)/github.com/planetscale/vtprotobuf
 
 $(PROTO_DEPS_PATH)/github.com/googleapis/googleapis:
 	git clone \
@@ -191,3 +192,9 @@ $(PROTO_DEPS_PATH)/github.com/envoyproxy/protoc-gen-validate:
 		--depth 1 \
 		https://github.com/envoyproxy/protoc-gen-validate \
 		$(PROTO_DEPS_PATH)/github.com/envoyproxy/protoc-gen-validate
+
+$(PROTO_DEPS_PATH)/github.com/planetscale/vtprotobuf:
+	git clone \
+		--depth 1 \
+		https://github.com/planetscale/vtprotobuf \
+		$(PROTO_DEPS_PATH)/github.com/planetscale/vtprotobuf

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ sourceSets {
             exclude '**/tests/**/*.proto'
             exclude '**/test/**/*.proto'
             exclude '**/testprotos/**/*.proto'
+            exclude '**/testproto/**/*.proto'
             exclude '**/testdata/**/*.proto'
 
             exclude '**/googleapis/googleapis/**/*.proto'
@@ -80,6 +81,7 @@ sourceSets {
             include '**/tests/**/*.proto'
             include '**/test/**/*.proto'
             include '**/testprotos/**/*.proto'
+            include '**/testproto/**/*.proto'
             include '**/testdata/**/*.proto'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.21'
+    ext.kotlin_version = '1.8.22'
     repositories {
         mavenCentral()
         //Needed only for SNAPSHOT versions
@@ -110,7 +110,7 @@ dependencies {
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'io.envoyproxy.protoc-gen-validate:pgv-java-stub:0.6.13'
 
-    testImplementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.21'
+    testImplementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.22'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
     testImplementation 'io.grpc:grpc-okhttp:1.55.1'


### PR DESCRIPTION
This PR fixes the build error of java client, due to the new dependencies added to Vald proto file and not able to resolve it.
Ref: https://github.com/vdaas/vald/pull/2044/files#diff-f0518b37b4e7594ba7a1a8470df48d49f9f4720d1f76871ca4cffa65be665b89

It is fixed by downloading the dependency before the proto is built.