### PR TITLE
Use CI_TOKEN for gh command

### DIFF
--- a/.github/workflows/pr-auto-merge.yaml
+++ b/.github/workflows/pr-auto-merge.yaml
@@ -39,7 +39,7 @@ jobs:
       - e2e
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.CI_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The workflow doesn't work after auto-merge, so we use `CI_TOKEN`.